### PR TITLE
E2E test shall not rely on Nodes keeping the same name once recreated

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -77,7 +77,7 @@ var _ = Describe("E2E tests", func() {
 					return len(newWorkers.Items)
 				}, 15*time.Minute, 10*time.Second).Should(BeNumerically("==", len(initialWorkers.Items)))
 
-				newNode := &v1.Node{}
+				var newNode *v1.Node
 				for _, n := range newWorkers.Items {
 					if n.GetCreationTimestamp().Time.After(mdr.GetCreationTimestamp().Time) {
 						newNode = &n


### PR DESCRIPTION
Currently, the E2E test waits for the deleted Node to reappear with the same name after Machine deletion; however, there is no guarantee that the new Node will have the same name.

With this change, the E2E test waits for the original number of Nodes to be restored, and only then it picks the one created after the CR and verifies that its associated Machine was created after the CR.

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>