### PR TITLE
Add missing template.spec field to MDR Template

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -18,7 +18,11 @@ metadata:
           "metadata": {
             "name": "machinedeletionremediationtemplate-sample"
           },
-          "spec": null
+          "spec": {
+            "template": {
+              "spec": {}
+            }
+          }
         }
       ]
     capabilities: Basic Install

--- a/config/samples/machine-deletion-remediation_v1alpha1_machinedeletionremediationtemplate.yaml
+++ b/config/samples/machine-deletion-remediation_v1alpha1_machinedeletionremediationtemplate.yaml
@@ -3,4 +3,5 @@ kind: MachineDeletionRemediationTemplate
 metadata:
   name: machinedeletionremediationtemplate-sample
 spec:
-  # TODO(user): Add fields here
+  template:
+    spec: {}


### PR DESCRIPTION
Without this field, even if empty, the default MDR Template is invalid.