### PR TITLE
Fix PodSecurity "restricted" warning

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -191,6 +191,9 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: machine-deletion-remediation-controller-manager

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: default
+namespace: machine-deletion-remediation
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Containers shall drop all capabilities to comply with restricted PSA profile.

Also deploy under custom namespace in place of "default".