### PR TITLE
Applying markdownlint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
 # Machine-API Driven Remediation
 
-This operator conforms to the External Remediation of [NodeHealthCheck](https://github.com/medik8s/node-healthcheck-operator#readme) and is designed to work with [Node Health Check]((https://github.com/medik8s/node-healthcheck-operator#readme)) to reprovision unhealthy nodes using the [Machine API](https://github.com/openshift/machine-api-operator#readme). It functions by following the annotation on the Node to the associated Machine object, confirms that it has an owning controller (e.g. MachineSetController), and deletes it.  Once the Machine CR has been deleted, the owning controller creates a replacement. 
+This operator conforms to the External Remediation of [NodeHealthCheck](https://github.com/medik8s/node-healthcheck-operator#readme) and is designed to work with [Node Health Check](https://github.com/medik8s/node-healthcheck-operator#readme) to reprovision unhealthy nodes using the [Machine API](https://github.com/openshift/machine-api-operator#readme). It functions by following the annotation on the Node to the associated Machine object, confirms that it has an owning controller (e.g. MachineSetController), and deletes it.  Once the Machine CR has been deleted, the owning controller creates a replacement.
 
 ## Pre-requisites
+
 * Machine API based cluster that is able to programmatically destroy and create cluster nodes
 * Nodes are associated with Machines
 * Machines are declaratively managed
-* Node Health Check is installed and running 
+* Node Health Check is installed and running
 
 ## Installation
-- Deploy MDR (Machine-deletion-remediation) to a container in the cluster pod. Try `make deploy`, official images coming soon.
-- Load the yaml manifest of the MDR template (see below).
-- Modifying NodeHealthCheck CR to use MDR as it's remediator.
+
+* Deploy MDR (Machine-deletion-remediation) to a container in the cluster pod. Try `make deploy`, official images coming soon.
+
+* Load the yaml manifest of the MDR template (see below).
+
+* Modifying NodeHealthCheck CR to use MDR as it's remediator.
 This is basically a specific use case of an External Remediation of [NodeHealthCheck](https://github.com/medik8s/node-healthcheck-operator#readme).
 In order to set up: make sure that Node Health Check is running, Machine-deletion-remediation controller exists and then create the necessary CRs.
 
 ## Example CRs
+
 An example MDR template object.
+
 ```yaml
    apiVersion: machine-deletion-remediation.medik8s.io/v1alpha1
    kind: MachineDeletionRemediationTemplate
@@ -27,9 +33,11 @@ An example MDR template object.
      template:
        spec: {}
 ```
+
 These CRs are created by the admin and are used as a template by NodeHealthCheck for creating the CRs that represent a request for a Node to be recovered.
 
 Configuring NodeHealthCheck to use the example `group-x` template above.
+
 ```yaml
 apiVersion: remediation.medik8s.io/v1alpha1
 kind: NodeHealthCheck
@@ -42,10 +50,11 @@ spec:
     name: group-x
     namespace: default
 ```
+
 While the admin may define many NodeHealthCheck domains, they can all use the same MDR template if desired.
 
-
 An example remediation request for Node `worker-0-21` (NOTE: *uid* is the nodehealthcheck-sample's UID).
+
 ```yaml
 apiVersion: machine-deletion-remediation.medik8s.io/v1alpha1
 kind: MachineDeletionRemediation
@@ -59,6 +68,7 @@ metadata:
       uid: 754189c9-b0d2-4894-bb2c-6adbdccb26f8
 spec: {}
 ```
-These CRs are created by NodeHealthCheck when it detects a failed node. 
+
+These CRs are created by NodeHealthCheck when it detects a failed node.
 The MDR operator watches for them to be created, looks up the Machine CR and deletes Node associated with it.
-MDR CRs are deleted by NodeHealthCheck when it sees the Node is healthy again. 
+MDR CRs are deleted by NodeHealthCheck when it sees the Node is healthy again.


### PR DESCRIPTION
The [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) from VSCODE found seven warnings:

-  [MD004 - Unordered list style](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md004.md)
-  [MD009 - Trailing spaces](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md009.md)
-  [MD012 - Multiple consecutive blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md012.md)
- [MD022 - Headings should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md022.md)
- [MD031 - Fenced code blocks should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md031.md)
- [MD032 - Lists should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md032.md)
- [MD034 - Bare URL used](https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md034.md)