### PR TITLE
Improve reconcile logging

### DIFF
--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -93,7 +93,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 	log.Info("node-associated machine found", "machine", machine.GetName(), "node name", node.Name)
 
 	if !hasControllerOwner(machine) {
-		log.Info("ignoring remediation of machine associated to node, since the machine has no controller owner", "machine", machine.GetName(), "node name", remediation.Name)
+		log.Info("ignoring remediation of node-associated machine: the machine has no controller owner", "machine", machine.GetName(), "node name", remediation.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -118,7 +118,7 @@ func (r *MachineDeletionRemediationReconciler) deleteMachineOfNode(ctx context.C
 	//verify machine is deleted
 	if err := r.Get(ctx, key, machine); err != nil {
 		if apiErrors.IsNotFound(err) {
-			r.Log.Info("machine associated to node correctly deleted", "machine", key.Name, "node", nodeName)
+			r.Log.Info("node-associated machine correctly deleted", "machine", key.Name, "node", nodeName)
 			return nil
 		}
 		r.Log.Error(err, "unexpected error retrieving the node-associated machine after deletion request", "machine", key.Name, "node", nodeName)
@@ -127,10 +127,10 @@ func (r *MachineDeletionRemediationReconciler) deleteMachineOfNode(ctx context.C
 
 	machinePhase, err := getMachineStatusPhase(machine)
 	if err != nil {
-		r.Log.Error(err, "could not get machine phase")
+		r.Log.Error(err, "could not get machine's phase")
 		machinePhase = "unknown"
 	}
-	r.Log.Info("machine associated to node was not deleted yet, probably due to a finalizer on the machine", "machine", key.Name, "machine status.phase", machinePhase)
+	r.Log.Info("node-associated machine was not deleted yet, probably due to a finalizer on the machine", "machine", key.Name, "machine status.phase", machinePhase)
 
 	return nil
 }
@@ -160,7 +160,7 @@ func (r *MachineDeletionRemediationReconciler) getRemediation(ctx context.Contex
 			r.Log.Info("MDR already deleted, nothing to do")
 			return nil, nil
 		}
-		r.Log.Error(err, "error retrieving remediation in namespace", "remediation name", req.Name, "namespace", req.Namespace)
+		r.Log.Error(err, "could not find remediation object in namespace", "remediation name", req.Name, "namespace", req.Namespace)
 		return nil, err
 	}
 	return remediation, nil

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -81,19 +81,21 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 		r.Log.Error(err, "failed to fetch node", "node name", remediation.Name)
 		return ctrl.Result{}, err
 	}
+	log.Info("reconciling...")
 
 	var machine *unstructured.Unstructured
 	if machine, err = r.buildMachineFromNode(node); err != nil {
 		r.Log.Error(err, "failed to fetch machine of node", "node name", node.Name)
 		return ctrl.Result{}, err
 	}
+	log.Info("node-associated machine found", "machine", machine.GetName())
 
 	if !hasControllerOwner(machine) {
-		r.Log.Info("ignoring remediation of machine associated to node, since the machine has no controller owner", "node name", remediation.Name)
+		log.Info("ignoring remediation of machine associated to node, since the machine has no controller owner", "node name", remediation.Name)
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("reconciling", "node", remediation.Name, "associated machine", machine.GetName())
+	log.Info("request machine deletion", "machine", machine.GetName())
 	if err := r.deleteMachineOfNode(ctx, machine, remediation.Name); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -211,22 +211,20 @@ func extractNameAndNamespace(nameNamespace string, nodeName string) (string, str
 }
 
 func getMachineStatusPhase(machine *unstructured.Unstructured) (string, error) {
-	phase := "unknown"
-
 	status, ok, err := unstructured.NestedMap(machine.Object, "status")
 	if err != nil {
-		return phase, fmt.Errorf("could not get Machine's status: error %v", err)
+		return "", fmt.Errorf("could not get Machine's status: error %w", err)
 	}
 	if !ok {
-		return phase, fmt.Errorf("Machine object does not have a status field")
+		return "", fmt.Errorf("Machine object does not have a status field")
 	}
 
-	phase, ok, err = unstructured.NestedString(status, "phase")
+	phase, ok, err := unstructured.NestedString(status, "phase")
 	if err != nil {
-		return phase, fmt.Errorf("could not get Machine's status.phase: error %v", err)
+		return "", fmt.Errorf("could not get Machine's status.phase: error %w", err)
 	}
 	if !ok {
-		return phase, fmt.Errorf("Machine object does not have a status.phase field")
+		return "", fmt.Errorf("Machine object does not have a status.phase field")
 	}
 	return phase, nil
 }

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -70,8 +70,6 @@ type MachineDeletionRemediationReconciler struct {
 func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("machinedeletionremediation", req.NamespacedName)
 
-	log.Info("reconciling...")
-
 	//fetch the remediation
 	var remediation *v1alpha1.MachineDeletionRemediation
 	if remediation = r.getRemediation(ctx, req); remediation == nil {
@@ -95,6 +93,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 		return ctrl.Result{}, err
 	}
 
+	log.Info("reconciling", "node", remediation.Name, "associated machine", machine.GetName())
 	if err := r.deleteMachineOfNode(ctx, machine, remediation.Name); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"os"
 
+	"go.uber.org/zap/zapcore"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -59,6 +61,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
- Log start of reconcile only when it is about to happen
- Refactor getRemediation function to handle errors more gracefully
- Refactor Reconcile function to improve clarity
- Add log for each main Reconcile step
- Log machine status after deletion request
- Use TimeEncoder in logging

[ECOPROJECT-1188](https://issues.redhat.com/browse/ECOPROJECT-1188)
