### PR TITLE
Fix timeout error in unittests

### DIFF
--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -219,12 +219,11 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 
 			When("machine associated to worker node fails deletion", func() {
 				It("returns the same delete failure error", func() {
-
 					Eventually(func() bool {
 						_ = k8sClient.Create(context.Background(), workerNodeMachine) //make sure worker machine will exist - it may be deleted by first run
 						_, reconcileError = reconciler.Reconcile(context.Background(), reconcileRequest)
 						return reconcileError != nil && reconcileError.Error() == mockDeleteFailMessage
-					}, 10*time.Second, 1*time.Second).Should(BeTrue())
+					}, 60*time.Second, 1*time.Second).Should(BeTrue())
 				})
 
 				BeforeEach(func() {


### PR DESCRIPTION
CI running unittest times out sometimes. Extend the timeout from 10 to
60 seconds.

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
