### PR TITLE
Verify Machine is actually deleted

### DIFF
--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -92,7 +92,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 		r.Log.Error(err, "failed to fetch machine of node", "node name", node.Name)
 		return ctrl.Result{}, err
 	}
-	log.Info("node-associated machine found", "machine", machine.GetName(), "node name", node.Name)
+	log.Info("node-associated machine found", "node", node.Name, "machine", machine.GetName())
 
 	if !hasControllerOwner(machine) {
 		log.Info("ignoring remediation of node-associated machine: the machine has no controller owner", "machine", machine.GetName(), "node name", remediation.Name)

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -209,12 +209,19 @@ func (r *MachineDeletionRemediationReconciler) verifyMachineIsDeleted(ctx contex
 			return false, err
 		}
 
+		message := "node-associated machine was not deleted yet"
+		machineFinalizersNo := len(machine.GetFinalizers())
+		if machineFinalizersNo > 0 {
+			message += fmt.Sprintf(", %d %s", machineFinalizersNo, "finalizer(s) on the machine")
+		}
+
 		machinePhase, err := getMachineStatusPhase(machine)
 		if err != nil {
 			r.Log.Error(err, "could not get machine's phase")
 			machinePhase = "unknown"
 		}
-		r.Log.Info("node-associated machine was not deleted yet, probably due to a finalizer on the machine", "node", nodeName, "machine", key.Name, "machine status.phase", machinePhase, "next check", pollTime)
+
+		r.Log.Info(message, "node", nodeName, "machine", key.Name, "machine status.phase", machinePhase, "next check", pollTime)
 		return false, nil
 	})
 }


### PR DESCRIPTION
Currently, after requesting Machine deletion, the Reconciler checks only
once if the machine was actually deleted, which is usually not the case
due to Finalizer in the machine.

With this change, the Reconciler continues to check if Machine existence
until deletion.

[ECOPROJECT-1188](https://issues.redhat.com/browse/ECOPROJECT-1188)
