### PR TITLE
Rework controller unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,9 +157,12 @@ fetch-mutation: ## fetch mutation package.
 	GO111MODULE=off go get -t -v github.com/mshitrit/go-mutesting/...
 
 # Run tests
+# Use TEST_OPS to pass further options to `go test` (e.g. verbosity and/or -ginkgo.focus)
+export TEST_OPS ?= ""
+.PHONY: test
 test: manifests generate test-imports fmt vet envtest 
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path  --bin-dir $(PROJECT_DIR)/testbin)" \
-		go test ./controllers/... -coverprofile cover.out
+		go test ./controllers/... -coverprofile cover.out ${TEST_OPS}
 
 test-mutation: verify-no-changes fetch-mutation ## Run mutation tests in manual mode.
 	echo -e "## Verifying diff ## \n##Mutations tests actually changes the code while running - this is a safeguard in order to be able to easily revert mutation tests changes (in case mutation tests have not completed properly)##"

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -43,6 +43,9 @@ const (
 	machineSetKind             = "MachineSet"
 	// MachineNameNamespaceAnnotation contains to-be-deleted Machine's Name and Namespace
 	MachineNameNamespaceAnnotation = "machine-deletion-remediation.medik8s.io/machineNameNamespace"
+	// Infos
+	postponedMachineDeletionInfo  = "node-associated machine was not deleted yet"
+	successfulMachineDeletionInfo = "node-associated machine correctly deleted"
 	//Errors
 	noAnnotationsError                 = "failed to find machine annotation on node name: %s"
 	noMachineAnnotationError           = "failed to find openshift machine annotation on node name: %s"
@@ -238,7 +241,7 @@ func (r *MachineDeletionRemediationReconciler) verifyMachineIsDeleted(ctx contex
 	machine.SetAPIVersion(v1beta1.SchemeGroupVersion.String())
 	if err := r.Get(ctx, key, machine); err != nil {
 		if apiErrors.IsNotFound(err) {
-			r.Log.Info("node-associated machine correctly deleted", "node", nodeName, "machine", machineName)
+			r.Log.Info(successfulMachineDeletionInfo, "node", nodeName, "machine", machineName)
 			return true, nil
 		}
 		r.Log.Error(err, "unexpected error retrieving the node-associated machine after deletion request", "node", nodeName, "machine", key.Name)
@@ -251,7 +254,7 @@ func (r *MachineDeletionRemediationReconciler) verifyMachineIsDeleted(ctx contex
 		machinePhase = "unknown"
 	}
 
-	r.Log.Info("node-associated machine was not deleted yet", "node", nodeName, "machine", machineName, "machine status.phase", machinePhase)
+	r.Log.Info(postponedMachineDeletionInfo, "node", nodeName, "machine", machineName, "machine status.phase", machinePhase)
 	return false, nil
 }
 

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -48,6 +48,8 @@ const (
 	noMachineAnnotationError           = "failed to find openshift machine annotation on node name: %s"
 	invalidValueMachineAnnotationError = "failed to extract Machine Name and Machine Namespace from machine annotation on the node for node name: %s"
 	failedToDeleteMachineError         = "failed to delete machine of node name: %s"
+	noNodeFoundError                   = "failed to fetch node"
+	noMachineFoundError                = "failed to fetch machine of node"
 )
 
 // MachineDeletionRemediationReconciler reconciles a MachineDeletionRemediation object
@@ -115,7 +117,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 
 	var machine *unstructured.Unstructured
 	if machine, err = r.buildMachineFromNode(node); err != nil {
-		r.Log.Error(err, "failed to fetch machine of node", "node name", node.Name)
+		r.Log.Error(err, noMachineFoundError, "node name", node.Name)
 		return ctrl.Result{}, err
 	}
 
@@ -186,7 +188,7 @@ func (r *MachineDeletionRemediationReconciler) getNodeFromMdr(mdr *v1alpha1.Mach
 	}
 
 	if err := r.Get(context.Background(), key, node); err != nil {
-		r.Log.Error(err, "failed to fetch node", "node name", mdr.Name)
+		r.Log.Error(err, noNodeFoundError, "node name", mdr.Name)
 		return nil, err
 	}
 	return node, nil

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 		)
 
 		BeforeEach(func() {
+			plogs.Clear()
 			isDeleteWorkerNodeMachine = true
 			workerNodeMachine, masterNodeMachine = createWorkerMachine(workerNodeMachineName), createMachine(masterNodeMachineName)
 			workerNode, masterNode, phantomNode = createNodeWithMachine(workerNodeName, workerNodeMachine), createNodeWithMachine(masterNodeName, masterNodeMachine), createNode(noneExistingNodeName)

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -305,14 +305,6 @@ func verifyMachineIsDeleted(machineName string) {
 	}).Should(BeTrue())
 }
 
-type deleteFailClient struct {
-	client.Client
-}
-
-func (deleteFailClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	return fmt.Errorf(mockDeleteFailMessage)
-}
-
 func deleteIgnoreNotFound() func(ctx context.Context, obj client.Object) error {
 	return func(ctx context.Context, obj client.Object) error {
 		if err := k8sClient.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -151,6 +151,27 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					Expect(underTest.GetAnnotations()).ToNot(BeNil())
 				})
 			})
+
+			When("machine deletion is not completed yet", func() {
+				BeforeEach(func() {
+					// Worker deletion requested, but not completed yet (possibly due to finalizer in the Machine)
+					underTest = createRemediationWithAnnotation(workerNode, workerNodeMachine)
+				})
+
+				It("logs machine status until deletion", func() {
+					Eventually(func() bool {
+						return plogs.Contains(postponedMachineDeletionInfo)
+					}, 10*time.Second, 1*time.Second).Should(BeTrue())
+
+					// Mock a postponed machine deletion
+					Expect(k8sClient.Delete(context.Background(), workerNodeMachine)).ToNot(HaveOccurred())
+					isDeleteWorkerNodeMachine = false
+
+					Eventually(func() bool {
+						return plogs.Contains(successfulMachineDeletionInfo)
+					}, 60*time.Second, 1*time.Second).Should(BeTrue())
+				})
+			})
 		})
 
 		Context("Rainy (Error) Flows", func() {
@@ -234,7 +255,6 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 				})
 			})
-
 		})
 	})
 })
@@ -243,6 +263,14 @@ func createRemediation(node *v1.Node) *v1alpha1.MachineDeletionRemediation {
 	mdr := &v1alpha1.MachineDeletionRemediation{}
 	mdr.Name = node.Name
 	mdr.Namespace = defaultNamespace
+	return mdr
+}
+
+func createRemediationWithAnnotation(node *v1.Node, machine *v1beta1.Machine) *v1alpha1.MachineDeletionRemediation {
+	mdr := createRemediation(node)
+	annotations := make(map[string]string, 1)
+	annotations[MachineNameNamespaceAnnotation] = fmt.Sprintf("%s/%s", machine.GetNamespace(), machine.GetName())
+	mdr.SetAnnotations(annotations)
 	return mdr
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -41,6 +41,15 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+var (
+	cclient   customClient
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+	plogs     *peekLogger
+)
+
 // peekLogger allows to inspect operator's log for testing purpose.
 type peekLogger struct {
 	logs []string
@@ -80,15 +89,6 @@ func (c *customClient) Delete(ctx context.Context, obj client.Object, opts ...cl
 	}
 	return c.Client.Delete(ctx, obj, opts...)
 }
-
-var (
-	cclient   customClient
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	ctx       context.Context
-	cancel    context.CancelFunc
-	plogs     *peekLogger
-)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
- Move setup code in front of test sections
- Add test logger
- Replace manual reconcile call with look-for-matches on error logs
- Increase test coverage with new test case
