### PR TITLE
Verify Golang Dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,18 @@ fmt: goimports ## Run go goimports against code - goimports = go fmt + fixing im
 vet:
 	go vet ./...
 
+.PHONY: go-tidy
+go-tidy: # Run go mod tidy - add missing and remove unused modules.
+	go mod tidy
+
+.PHONY: go-vendor
+go-vendor:  # Run go mod vendor - make vendored copy of dependencies.
+	go mod vendor
+
+.PHONY: go-verify
+go-verify: go-tidy go-vendor # Run go mod verify - verify dependencies have expected content
+	go mod verify
+
 .PHONY: test-imports
 test-imports: sort-imports ## Check for sorted imports
 	$(SORT_IMPORTS) .
@@ -160,7 +172,7 @@ fetch-mutation: ## fetch mutation package.
 # Use TEST_OPS to pass further options to `go test` (e.g. verbosity and/or -ginkgo.focus)
 export TEST_OPS ?= ""
 .PHONY: test
-test: manifests generate test-imports fmt vet envtest 
+test: manifests generate go-verify fmt vet test-imports envtest 
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path  --bin-dir $(PROJECT_DIR)/testbin)" \
 		go test ./controllers/... -coverprofile cover.out ${TEST_OPS}
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.7.0
 	github.com/onsi/gomega v1.24.1
 	github.com/openshift/machine-api-operator v0.2.1-0.20210104142355-8e6ae0acdfcf
+	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.21.0
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
@@ -53,7 +54,6 @@ require (
 	github.com/openshift/api v0.0.0-20201216151826-78a19e96f9eb // indirect
 	github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49 // indirect
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201201000827-1117a4fc438c // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect


### PR DESCRIPTION
Run "go mod" functions to search for go vendor changes and verify it before every `test` run.

Follow up to #50 and similar to [FAR's PR](https://github.com/medik8s/fence-agents-remediation/pull/2).