### PR TITLE
Set up Golang using go.mod file

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -21,9 +21,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
+        uses: actions/setup-go@v4
+        with: 
+          go-version-file: 'go.mod' 
+          cache-dependency-path: 'go.sum' 
 
       - name: Log in to Quay.io
         uses: docker/login-action@v2

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -16,9 +16,10 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19
+      uses: actions/setup-go@v4
+      with: 
+        go-version-file: 'go.mod' 
+        cache-dependency-path: 'go.sum' 
 
     - name: Build
       run: make manager

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,18 @@
 FROM quay.io/centos/centos:stream8 AS builder
 RUN dnf install git golang -y
 
-# Ensure go 1.19
-RUN go install golang.org/dl/go1.19@latest
-RUN ~/go/bin/go1.19 download
-RUN /bin/cp -f ~/go/bin/go1.19 /usr/bin/go
-RUN go version
-
 WORKDIR /workspace
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
+# Ensure correct Go version
+RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
+    go install golang.org/dl/go${GO_VERSION}@latest && \
+    ~/go/bin/go${GO_VERSION} download && \
+    /bin/cp -f ~/go/bin/go${GO_VERSION} /usr/bin/go && \
+    go version
 
 # Copy the go source
 COPY main.go main.go


### PR DESCRIPTION
Save time and possible errors of updating Golang version by fetching it from _go.mod_ file:

- No longer need to set Golang version in github CI.
- No longer need to set Golang version in Dockerfile.