### PR TITLE
Implement machine deletion error count threshold

### DIFF
--- a/api/v1alpha1/machinedeletionremediation_types.go
+++ b/api/v1alpha1/machinedeletionremediation_types.go
@@ -32,8 +32,9 @@ type MachineDeletionRemediationSpec struct {
 
 // MachineDeletionRemediationStatus defines the observed state of MachineDeletionRemediation
 type MachineDeletionRemediationStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// Consecutive number of errors upon deleting a Machine
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	ErrorOnDeleteCount int `json:"errorOnDeleteCount,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -50,6 +50,10 @@ spec:
       - kind: MachineDeletionRemediation
         name: machinedeletionremediations
         version: v1alpha1
+      statusDescriptors:
+      - description: Consecutive number of errors upon deleting a Machine
+        displayName: Error On Delete Count
+        path: errorOnDeleteCount
       version: v1alpha1
     - description: MachineDeletionRemediationTemplate is the Schema for the machinedeletionremediationtemplates
         API

--- a/bundle/manifests/machine-deletion-remediation.medik8s.io_machinedeletionremediations.yaml
+++ b/bundle/manifests/machine-deletion-remediation.medik8s.io_machinedeletionremediations.yaml
@@ -41,6 +41,10 @@ spec:
           status:
             description: MachineDeletionRemediationStatus defines the observed state
               of MachineDeletionRemediation
+            properties:
+              errorOnDeleteCount:
+                description: Consecutive number of errors upon deleting a Machine
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/machine-deletion-remediation.medik8s.io_machinedeletionremediations.yaml
+++ b/config/crd/bases/machine-deletion-remediation.medik8s.io_machinedeletionremediations.yaml
@@ -42,6 +42,10 @@ spec:
           status:
             description: MachineDeletionRemediationStatus defines the observed state
               of MachineDeletionRemediation
+            properties:
+              errorOnDeleteCount:
+                description: Consecutive number of errors upon deleting a Machine
+                type: integer
             type: object
         type: object
     served: true

--- a/config/manifests/bases/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/machine-deletion-remediation.clusterserviceversion.yaml
@@ -26,6 +26,10 @@ spec:
       - kind: MachineDeletionRemediation
         name: machinedeletionremediations
         version: v1alpha1
+      statusDescriptors:
+      - description: Consecutive number of errors upon deleting a Machine
+        displayName: Error On Delete Count
+        path: errorOnDeleteCount
       version: v1alpha1
     - description: MachineDeletionRemediationTemplate is the Schema for the machinedeletionremediationtemplates
         API

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -229,6 +229,14 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						return plogs.Contains(mockDeleteFailMessage)
 					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 				})
+
+				It("stops deletion retries after max attemps was reached", func() {
+					Eventually(func() bool {
+						return plogs.Contains(maxRetriesReachedFailMessage)
+					}, time.Second).Should(BeTrue(), "could not find message '%s' in logs", maxRetriesReachedFailMessage)
+
+					verifyMachineNotDeleted(workerNodeMachineName)
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Currently, the Reconcile loop would indefinitely re-queue for Machine
deletion errors.

This commit adds a limit to the number of such errors that, once the
limit is reached, interrupts the re-queue process.

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
