### PR TITLE
Fix wrong Condition value and reason when Node or Machine is not found

### DIFF
--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -70,7 +70,7 @@ type conditionChangeReason string
 const (
 	remediationStarted                  conditionChangeReason = "RemediationStarted"
 	remediationTimedOutByNhc            conditionChangeReason = "RemediationStoppedByNHC"
-	remediationFinished                 conditionChangeReason = "RemediationFinished"
+	remediationFinishedMachineDeleted   conditionChangeReason = "MachineDeleted"
 	remediationSkippedNodeNotFound      conditionChangeReason = "RemediationSkippedNodeNotFound"
 	remediationSkippedMachineNotFound   conditionChangeReason = "RemediationSkippedMachineNotFound"
 	remediationSkippedNoControllerOwner conditionChangeReason = "RemediationSkippedNoControllerOwner"
@@ -144,7 +144,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 			// finished. We return error only if updateConditions failed
 			var reason conditionChangeReason
 			if !mustExist {
-				reason = remediationFinished
+				reason = remediationFinishedMachineDeleted
 			} else if strings.Contains(err.Error(), noNodeFoundError) {
 				reason = remediationSkippedNodeNotFound
 			} else if strings.Contains(err.Error(), noMachineFoundError) {
@@ -378,7 +378,7 @@ func (r *MachineDeletionRemediationReconciler) updateConditions(reason condition
 	case remediationStarted:
 		processingConditionStatus = metav1.ConditionTrue
 		succeededConditionStatus = metav1.ConditionUnknown
-	case remediationFinished:
+	case remediationFinishedMachineDeleted:
 		processingConditionStatus = metav1.ConditionFalse
 		succeededConditionStatus = metav1.ConditionTrue
 	case remediationTimedOutByNhc,

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -171,8 +171,8 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					// the actual MDR CR. For this reason the initial value is not
 					// tested here.
 					verifyConditionsMatch([]expectedCondition{
-						{commonconditions.ProcessingType, metav1.ConditionFalse, remediationFinished},
-						{commonconditions.SucceededType, metav1.ConditionTrue, remediationFinished},
+						{commonconditions.ProcessingType, metav1.ConditionFalse, remediationFinishedMachineDeleted},
+						{commonconditions.SucceededType, metav1.ConditionTrue, remediationFinishedMachineDeleted},
 						// Cluster provider is not set in this test
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 
 				It("node not found error", func() {
 					Eventually(func() bool {
-						return plogs.Contains(noNodeFoundError)
+						return plogs.Contains(nodeNotFoundErrorMsg)
 					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 
 					verifyConditionsMatch([]expectedCondition{
@@ -300,7 +300,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 
 				It("failed to fetch machine error", func() {
 					Eventually(func() bool {
-						return plogs.Contains(noMachineFoundError)
+						return plogs.Contains(machineNotFoundErrorMsg)
 					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 
 					verifyConditionsMatch([]expectedCondition{

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -187,7 +187,7 @@ func verifyStatusCondition(conditionType string, conditionStatus metav1.Conditio
 			return processingConditionSetAndMatchSuccess
 		}
 		return processingConditionSetButNoMatchError
-	}, "30s", "1s").Should(Equal(processingConditionSetAndMatchSuccess))
+	}, "60s", "1s").Should(Equal(processingConditionSetAndMatchSuccess))
 }
 
 func getPlatform(c client.Client) (string, error) {


### PR DESCRIPTION
Currently if Node or Machine were not found, Succeeded condition is set
to True and the reason to RemediationFinished, which is wrong.

This change not only fixes Succeded condition to False, but introduces
also a set of new reasons:

- remediationSkippedNodeNotFound
- remediationSkippedMachineNotFound
- remediationSkippedNoControllerOwner
- remediationFailed

the latter being set when remediation fails for more generic reasons
(e.g. unability to get the proper annotations from CR or Node).

fixes https://issues.redhat.com/browse/ECOPROJECT-1490
fixes https://issues.redhat.com/browse/ECOPROJECT-1493

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>
