### PR TITLE
Refine test workflows and integrate uncommitted changes check

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -26,9 +26,3 @@ jobs:
 
     - name: Test
       run: make test
-
-#    - name: Run codacy-coverage-reporter
-#      run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --project-token ${{ secrets.CODACY_PROJECT_TOKEN }}  --language go --force-coverage-parser go -r cover.out
-
-    - name: TestMutations
-      run: make test-mutation-ci

--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
-FILE_DIFF=$(git ls-files -o --exclude-standard)
 
-if [ "$FILE_DIFF" != "" ]; then
-  echo "Found untracked files:"
-  echo "$FILE_DIFF"
-  exit 1
+status=0
+# Checks that there are no uncommitted changes.
+if [[ -n "$(git status --porcelain .)" ]]; then
+    echo "[!] Uncommitted files. Commit changes and run 'make test'."
+    # Ignore untracked files to avoid messing up with the CI.
+    echo "$(git status --porcelain .)"
+    let status=1
 fi
 
-git diff --exit-code
+# Checks that changes under config directory are reflected in the bundle directory.
+# This is to ensure that the bundle is up-to-date with the latest changes.
+# If this fails, run 'make bundle' to update the bundle.
+if [[ -n "$(git status --porcelain config/)" ]] && [[ -z "$(git status --porcelain bundle/)"  ]]; then
+    echo ""
+    echo "[!] Config folder has changes, but Bundle does not. Check if Bundle is out-of-date."
+    echo "$(git status --porcelain config/)"
+    let status=1
+fi
+
+exit $status

--- a/vendor/github.com/go-task/slim-sprig/.editorconfig
+++ b/vendor/github.com/go-task/slim-sprig/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 8
+
+[*.{md,yml,yaml,json}]
+indent_style = space
+indent_size = 2

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
@@ -1,0 +1,63 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2/ginkgo/command"
+	"github.com/onsi/ginkgo/v2/ginkgo/internal"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func BuildBuildCommand() command.Command {
+	var cliConfig = types.NewDefaultCLIConfig()
+	var goFlagsConfig = types.NewDefaultGoFlagsConfig()
+
+	flags, err := types.BuildBuildCommandFlagSet(&cliConfig, &goFlagsConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	return command.Command{
+		Name:     "build",
+		Flags:    flags,
+		Usage:    "ginkgo build <FLAGS> <PACKAGES>",
+		ShortDoc: "Build the passed in <PACKAGES> (or the package in the current directory if left blank).",
+		DocLink:  "precompiling-suites",
+		Command: func(args []string, _ []string) {
+			var errors []error
+			cliConfig, goFlagsConfig, errors = types.VetAndInitializeCLIAndGoConfig(cliConfig, goFlagsConfig)
+			command.AbortIfErrors("Ginkgo detected configuration issues:", errors)
+
+			buildSpecs(args, cliConfig, goFlagsConfig)
+		},
+	}
+}
+
+func buildSpecs(args []string, cliConfig types.CLIConfig, goFlagsConfig types.GoFlagsConfig) {
+	suites := internal.FindSuites(args, cliConfig, false).WithoutState(internal.TestSuiteStateSkippedByFilter)
+	if len(suites) == 0 {
+		command.AbortWith("Found no test suites")
+	}
+
+	internal.VerifyCLIAndFrameworkVersion(suites)
+
+	opc := internal.NewOrderedParallelCompiler(cliConfig.ComputedNumCompilers())
+	opc.StartCompiling(suites, goFlagsConfig)
+
+	for {
+		suiteIdx, suite := opc.Next()
+		if suiteIdx >= len(suites) {
+			break
+		}
+		suites[suiteIdx] = suite
+		if suite.State.Is(internal.TestSuiteStateFailedToCompile) {
+			fmt.Println(suite.CompilationError.Error())
+		} else {
+			fmt.Printf("Compiled %s.test\n", suite.PackageName)
+		}
+	}
+
+	if suites.CountWithState(internal.TestSuiteStateFailedToCompile) > 0 {
+		command.AbortWith("Failed to compile all tests")
+	}
+}


### PR DESCRIPTION
- Update test target in Makefile to run unit tests followed by
  uncommitted changes verification.
- Enhance `verify-diff.sh` to detect uncommitted changes
  and out-of-date bundle.
- Remove mutation testing references from CI and Makefile.
