### PR TITLE
Support Operator Upgrades 

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -31,6 +31,7 @@ metadata:
     createdAt: ""
     description: Machine Deletion Remediation operator for reprovisioning unhealthy
       nodes using the Machine API.
+    olm.skipRange: '>=0.0.1'
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/medik8s/machine-deletion-remediation

--- a/config/manifests/bases/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/machine-deletion-remediation.clusterserviceversion.yaml
@@ -9,6 +9,7 @@ metadata:
     createdAt: ""
     description: Machine Deletion Remediation operator for reprovisioning unhealthy
       nodes using the Machine API.
+    olm.skipRange: '>=0.0.1'
     repository: https://github.com/medik8s/machine-deletion-remediation
     support: Medik8s
   name: machine-deletion-remediation.v0.0.0


### PR DESCRIPTION
Adding olm.skiprange will enable MDR to be upgradeable.

For more on SkipRange see https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange