### PR TITLE
Set Processing and Succeeded conditions only when resources are restored

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -136,6 +136,14 @@ spec:
         - apiGroups:
           - machine.openshift.io
           resources:
+          - controlplanemachinesets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - machine.openshift.io
+          resources:
           - machines
           verbs:
           - create

--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -146,6 +146,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - machine.openshift.io
+          resources:
+          - machinesets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,14 @@ rules:
 - apiGroups:
   - machine.openshift.io
   resources:
+  - controlplanemachinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - machine.openshift.io
+  resources:
   - machines
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,3 +50,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -45,7 +45,6 @@ import (
 
 const (
 	machineAnnotationOpenshift = "machine.openshift.io/machine"
-	machineKind                = "Machine"
 	// MachineNameNsAnnotation contains to-be-deleted Machine's Name and Namespace
 	MachineNameNsAnnotation = "machine-deletion-remediation.medik8s.io/machineNameNamespace"
 	// MachineOwnerAnnotation contains Machine's ownerReference name and Kind

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -128,7 +128,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 	nodeName := remediation.GetName()
 
 	if r.isTimedOutByNHC(remediation) {
-		log.Info("NHC stop requested")
+		log.Info("NHC time out annotation found, stopping remediation")
 		_, err = r.updateConditions(remediationTimedOutByNhc, remediation)
 		return ctrl.Result{}, err
 	}

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 
 			When("Remediation has incorrect annotation", func() {
 				BeforeEach(func() {
-					underTest = createRemediationWithAnnotation(masterNode, MachineNameNsAnnotation, "Gibberish")
+					underTest = createRemediationWithAnnotation(masterNode, MachineDataAnnotation, "Gibberish")
 				})
 
 				It("fails to follow machine deletion", func() {

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -494,7 +494,7 @@ func verifyConditionMatches(conditionType string, conditionStatus metav1.Conditi
 		}
 
 		return processingConditionSetAndMatchSuccess
-	}, "60s", "1s").Should(Equal(processingConditionSetAndMatchSuccess), "'%v' status condition was expected to be %v and reason %v", conditionType, conditionStatus, reason)
+	}, "60s", "10s").Should(Equal(processingConditionSetAndMatchSuccess), "'%v' status condition was expected to be %v and reason %v", conditionType, conditionStatus, reason)
 }
 
 func verifyConditionsMatch(expectedConditions []expectedCondition) {

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -24,6 +24,7 @@ import (
 const (
 	defaultNamespace                                     = "default"
 	machineSetName                                       = "machine-set-x"
+	machineSetKind                                       = "MachineSet"
 	dummyMachine                                         = "dummy-machine"
 	workerNodeName, masterNodeName, noneExistingNodeName = "worker-node-x", "master-node-x", "phantom-node"
 	workerNodeMachineName, masterNodeMachineName         = "worker-node-x-machine", "master-node-x-machine"
@@ -328,7 +329,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 
 			When("Remediation has incorrect annotation", func() {
 				BeforeEach(func() {
-					underTest = createRemediationWithAnnotation(masterNode, MachineDataAnnotation, "Gibberish")
+					underTest = createRemediationWithAnnotation(masterNode, MachineNameNsAnnotation, "Gibberish")
 				})
 
 				It("fails to follow machine deletion", func() {

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 			underTest = &v1alpha1.MachineDeletionRemediation{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: defaultNamespace},
 			}
-			DeferCleanup(k8sClient.Delete, underTest)
 			Expect(k8sClient.Create(context.Background(), underTest)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, underTest)
 		})
 
 		When("creating a resource", func() {
@@ -77,21 +77,21 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 			workerNodeMachine, masterNodeMachine = createWorkerMachine(workerNodeMachineName), createMachine(masterNodeMachineName)
 			workerNode, masterNode, phantomNode = createNodeWithMachine(workerNodeName, workerNodeMachine), createNodeWithMachine(masterNodeName, masterNodeMachine), createNode(noneExistingNodeName)
 
-			DeferCleanup(k8sClient.Delete, machineSet)
-			DeferCleanup(k8sClient.Delete, masterNode)
-			DeferCleanup(k8sClient.Delete, workerNode)
-			DeferCleanup(k8sClient.Delete, masterNodeMachine)
-			DeferCleanup(deleteIgnoreNotFound(), workerNodeMachine)
 			Expect(k8sClient.Create(context.Background(), machineSet)).To(Succeed())
 			Expect(k8sClient.Create(context.Background(), masterNode)).To(Succeed())
 			Expect(k8sClient.Create(context.Background(), workerNode)).To(Succeed())
 			Expect(k8sClient.Create(context.Background(), masterNodeMachine)).To(Succeed())
 			Expect(k8sClient.Create(context.Background(), workerNodeMachine)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, machineSet)
+			DeferCleanup(k8sClient.Delete, masterNode)
+			DeferCleanup(k8sClient.Delete, workerNode)
+			DeferCleanup(k8sClient.Delete, masterNodeMachine)
+			DeferCleanup(deleteIgnoreNotFound(), workerNodeMachine)
 		})
 
 		JustBeforeEach(func() {
-			DeferCleanup(k8sClient.Delete, underTest)
 			Expect(k8sClient.Create(context.Background(), underTest)).To(Succeed())
+			DeferCleanup(k8sClient.Delete, underTest)
 		})
 
 		Context("Sunny Flows", func() {

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+
 	appv1alpha1 "github.com/medik8s/machine-deletion-remediation/api/v1alpha1"
 	"github.com/medik8s/machine-deletion-remediation/controllers"
 	"github.com/medik8s/machine-deletion-remediation/version"
@@ -48,8 +50,8 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
 	utilruntime.Must(appv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(machinev1beta1.Install(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
- Set Processing and Succeeded conditions only when resources are restored
- Save Machine Owner together with Name and Namespace in CR annotation
- Use `v1beta1.Machine` in place of `unstructured.Unstructured`
- Rephrased log for clarity
