### PR TITLE
Revert "Add status condition to MDR CSV sample"

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -10,26 +10,7 @@ metadata:
           "metadata": {
             "name": "machinedeletionremediation-sample"
           },
-          "spec": {},
-          "status": {
-            "conditions": [
-              {
-                "reason": "RemediationFinished",
-                "status": false,
-                "type": "Processing"
-              },
-              {
-                "reason": "RemediationFinished",
-                "status": true,
-                "type": "Succeeded"
-              },
-              {
-                "reason": "MachineDeletionOnBareMetalProviderReason",
-                "status": false,
-                "type": "PermanentNodeDeletionExpected"
-              }
-            ]
-          }
+          "spec": {}
         },
         {
           "apiVersion": "machine-deletion-remediation.medik8s.io/v1alpha1",

--- a/config/samples/machine-deletion-remediation_v1alpha1_machinedeletionremediation.yaml
+++ b/config/samples/machine-deletion-remediation_v1alpha1_machinedeletionremediation.yaml
@@ -3,14 +3,3 @@ kind: MachineDeletionRemediation
 metadata:
   name: machinedeletionremediation-sample
 spec: {}
-status:
-  conditions:
-  - type: Processing
-    status: false
-    reason: RemediationFinished
-  - type: Succeeded
-    status: true
-    reason: RemediationFinished
-  - type: PermanentNodeDeletionExpected
-    status: false
-    reason: MachineDeletionOnBareMetalProviderReason


### PR DESCRIPTION
This reverts commit 08149beedb65ab094cea7b2f546408791f0f88a0.

The sample is used in the UI to create MDR CR, which is not supposed to have `status` field by default.

see https://issues.redhat.com/browse/ECOPROJECT-1585