### PR TITLE
Update kube-rbac-proxy to v0.15.0

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -211,10 +211,11 @@ spec:
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
+                - --http2-disable
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: quay.io/brancz/kube-rbac-proxy:v0.14.4
+                image: quay.io/brancz/kube-rbac-proxy:v0.15.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,9 +10,10 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.14.4
+        image: quay.io/brancz/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
+        - "--http2-disable"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
         - "--v=10"


### PR DESCRIPTION
- update kube-rbac-proxy to v0.15.0
- disable HTTP/2 to prevent exploitation of CVE HTTP2 Rapid Reset

