### PR TITLE
Update Makefile to handle "replaces" CSV field

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -321,4 +321,5 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: machine-deletion-remediation.v0.0.1
   version: 0.0.1

--- a/config/manifests/bases/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/config/manifests/bases/machine-deletion-remediation.clusterserviceversion.yaml
@@ -104,4 +104,5 @@ spec:
   provider:
     name: Medik8s
     url: https://github.com/medik8s
+  replaces: machine-deletion-remediation.v0.0.1
   version: 0.0.0


### PR DESCRIPTION
Add "replaces" field to CSV and update Makefile's target bundle-update
to update the field with correct value

see: [ECOPROJECT-1769](https://issues.redhat.com/browse/ECOPROJECT-1769)
