### PR TITLE
Fix Remediation Started event

### DIFF
--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -78,10 +78,6 @@ const (
 	remediationSkippedMachineNotFound   conditionChangeReason = "RemediationSkippedMachineNotFound"
 	remediationSkippedNoControllerOwner conditionChangeReason = "RemediationSkippedNoControllerOwner"
 	remediationFailed                   conditionChangeReason = "RemediationFailed"
-
-	// Event reasons and messages
-	machineDeletionRequestedEventReason  = "MachineDeletionRequested"
-	machineDeletionRequestedEventMessage = "requesting machine deletion"
 )
 
 var (
@@ -135,7 +131,6 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 			finalResult.RequeueAfter = time.Second
 		}
 	}()
-	commonevents.RemediationStarted(r.Recorder, mdr)
 
 	if r.isTimedOutByNHC(mdr) {
 		log.Info("NHC time out annotation found, stopping remediation")
@@ -251,7 +246,8 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 		log.Error(err, "failed to delete machine", "machine", machine.GetName())
 		return ctrl.Result{}, err
 	}
-	commonevents.NormalEvent(r.Recorder, mdr, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage)
+	// The actual remediation has just started. This should be reached only once per CR.
+	commonevents.RemediationStarted(r.Recorder, mdr)
 
 	// requeue immediately to check machine deletion progression
 	return ctrl.Result{Requeue: true}, nil

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationSkippedNodeNotFound", "failed to fetch node", true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -168,7 +168,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationSkippedNoControllerOwner", noControllerOwnerErrorMsg, true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -190,7 +190,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationSkippedNoControllerOwner", noControllerOwnerErrorMsg, true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -214,7 +214,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationSkippedNoControllerOwner", noControllerOwnerErrorMsg, true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -257,7 +257,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						// Cluster provider is not set in this test
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, true},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", true},
 					})
 				})
 			})
@@ -295,7 +295,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						// Cluster provider is not set in this test
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, true},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", true},
 						{v1.EventTypeNormal, "RemediationFinished", "Remediation finished", true},
 					})
 				})
@@ -371,7 +371,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationSkippedNodeNotFound", "failed to fetch node", true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -394,7 +394,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationFailed", unrecoverableError.Error(), true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -417,7 +417,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationFailed", unrecoverableError.Error(), true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -440,7 +440,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationFailed", unrecoverableError.Error(), true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -463,7 +463,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationSkippedMachineNotFound", "failed to fetch machine of node", true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -487,7 +487,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeWarning, "RemediationFailed", unrecoverableError.Error(), true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -512,7 +512,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						// Cluster provider is not set in this test
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -532,7 +532,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyConditionUnset(commonconditions.PermanentNodeDeletionExpectedType)
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal, "RemediationStopped", "NHC added the timed-out annotation, remediation will be stopped", true},
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, false},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", false},
 					})
 				})
 			})
@@ -576,7 +576,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						// Cluster provider is not set in this test
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, true},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", true},
 					})
 				})
 			})
@@ -602,7 +602,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 						// Cluster provider is not set in this test
 						{commonconditions.PermanentNodeDeletionExpectedType, metav1.ConditionUnknown, v1alpha1.MachineDeletionOnUndefinedProviderReason}})
 					verifyEvents([]expectedEvent{
-						{v1.EventTypeNormal, machineDeletionRequestedEventReason, machineDeletionRequestedEventMessage, true},
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", true},
 					})
 				})
 			})


### PR DESCRIPTION
Emitting remediation started event at the beginning of the reconcile is
wrong. It makes think the actual remediation has started, while only the
reconcile loop has, and in fact, MDR might detect that no actual
remediation is necessary/possible later (e.g. No Node found).

This change emits the event when the remediation has actually started,
which is after the machine deletion request succeeded. For this reason,
the previous event "Machine deletion requested" was also removed because
it became a duplicate of the RemediationStarted.

This change addresses
* https://issues.redhat.com/browse/ECOPROJECT-1833
* https://issues.redhat.com/browse/ECOPROJECT-1834
* https://issues.redhat.com/browse/ECOPROJECT-1835