### PR TITLE
Fix events emitted twice

### DIFF
--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -133,9 +133,14 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 	}()
 
 	if r.isTimedOutByNHC(mdr) {
-		log.Info("NHC time out annotation found, stopping remediation")
-		commonevents.RemediationStoppedByNHC(r.Recorder, mdr)
-		_, err = r.updateConditions(remediationTimedOutByNhc, mdr)
+		updateRequired, err := r.updateConditions(remediationTimedOutByNhc, mdr)
+		if err == nil && updateRequired {
+			log.Info("NHC time out annotation found, stopping remediation")
+			commonevents.RemediationStoppedByNHC(r.Recorder, mdr)
+		} else {
+			// Status.Condition and event already handled, nothing to do
+		}
+		// return error only if updateConditions fails
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
- Handle NHC timed out event only once
- Emit RemediationFinished event only once

see:
https://issues.redhat.com/browse/ECOPROJECT-1860
https://issues.redhat.com/browse/ECOPROJECT-1861
