### PR TITLE
Use release tag for release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
           export VERSION=${VERSION} 
           export PREVIOUS_VERSION=${PREVIOUS_VERSION}
           export SKIP_RANGE_LOWER=${SKIP_RANGE_LOWER}
+          git -C operator checkout v${VERSION}
           rm -r operator/bundle && make -C operator bundle-community
 
       - name: Copy bundle


### PR DESCRIPTION
Current PR bundle automation is using main branch, while it should use
the tagged commit instead.
