### PR TITLE
Allow to create a test bundle for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: test-no-verify-changes ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 .PHONY: docker-push


### PR DESCRIPTION
Is currently not possible to create a test bundle (e.g. with changes or custom IMAGE_REGISTRY) due to `docker-build` target running `verify-no-changes` recipe

Let `docker-build` run only `test-no-verify-changes` to permit test bundles creation.
