### PR TITLE
Remove the catalog reference from release note

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -62,7 +62,6 @@ jobs:
 
             * Operator: quay.io/medik8s/machine-deletion-remediation-operator:${{ github.ref_name }}
             * Bundle: quay.io/medik8s/machine-deletion-remediation-operator-bundle:${{ github.ref_name }}
-            * Catalog aka Index: quay.io/medik8s/machine-deletion-remediation-operator-catalog:${{ github.ref_name }}
             
             ### Source code and OLM manifests
 


### PR DESCRIPTION
We won't create the catalog anymore, so remove the link from the release note