### PR TITLE
Fix verify-previous-version Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ BLUE_ICON_PATH = "./config/assets/medik8s_blue_icon.png"
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 DEFAULT_VERSION := 0.0.1
 VERSION ?= $(DEFAULT_VERSION)
-PREVIOUS_VERSION ?= $(VERSION)
+PREVIOUS_VERSION ?= $(DEFAULT_VERSION)
 export VERSION
 
 # CHANNELS define the bundle channels used in the bundle.
@@ -320,7 +320,8 @@ bundle-reset: ## Revert all version or build date related changes
 
 .PHONY: verify-previous-version
 verify-previous-version: ## Verifies that PREVIOUS_VERSION variable is set
-	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && [ $(PREVIOUS_VERSION) = $(DEFAULT_VERSION) ]; then \
+	@if [ $(VERSION) != $(DEFAULT_VERSION) ] && \
+		[ $(PREVIOUS_VERSION) == $(DEFAULT_VERSION) ]; then \
   			echo "Error: PREVIOUS_VERSION must be set for the selected VERSION"; \
     		exit 1; \
     fi


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
Previous version check is not working as expected.
It is supposed to check misalignment between its value and VERSION's one, however it is always set to VERSION's value.
Moreover, there's a typo in the test that checks this value.


This PR fixes the issue.

#### Changes made
<!-- Outline the specific changes made in this merge request. -->
- set PREVIOUS_VERSION default value to DEFAULT_VERSION instead than VERSION
- use double equal sign in PREVIOUS_VERSION test against DEFAULT_VERSION

This latter change isn't mandatory (bash supports single equal sign) but it is most common to see it with double equal sign

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->


#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
