### PR TITLE
Fix Go install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
 FROM quay.io/centos/centos:stream9 AS builder
-RUN dnf install git golang -y
+RUN dnf install git jq -y
 
 WORKDIR /workspace
 
@@ -8,10 +8,21 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Ensure correct Go version
-RUN export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
-    go get go@${GO_VERSION} && \
-    go version
+RUN \
+    # get Go version from mod file
+    export GO_VERSION=$(grep -E "go [[:digit:]]\.[[:digit:]][[:digit:]]" go.mod | awk '{print $2}') && \
+    echo ${GO_VERSION} && \
+    # find filename for latest z version from Go download page
+    export GO_FILENAME=$(curl -sL 'https://go.dev/dl/?mode=json&include=all' | jq -r "[.[] | select(.version | startswith(\"go${GO_VERSION}\"))][0].files[] | select(.os == \"linux\" and .arch == \"amd64\") | .filename") && \
+    echo ${GO_FILENAME} && \
+    # download and unpack
+    curl -sL -o go.tar.gz "https://golang.org/dl/${GO_FILENAME}" && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
+
+# add Go to PATH
+ENV PATH="${PATH}:/usr/local/go/bin"
+RUN go version
 
 # Copy the go source
 COPY main.go main.go


### PR DESCRIPTION
#### Why we need this PR

Currently, installing the latest z version of golang from the go
toolchain available in the repository (via go get) is failing with the
following error:

go: updating go.mod requires go >= 1.21.8 (running go 1.21.7; GOTOOLCHAIN=local)


#### Changes made

This change installs directly the wanted version from
https://golang.org/dl without using the distribution repository.
