### PR TITLE
Enhance release workflow by adding input validation for 'create_okd_release_pr'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,8 +17,8 @@ on:
        description: "The previous version, used for the CVS's `replaces` field, without the leading `v`"
        required: true
      ocp_version:
-       description: "The target OCP version for the release (mandatory for create_okd_release_pr option)"
-       required: true
+       description: "The target OCP version for the release (mandatory for 'create_okd_release_pr' operation)"
+       required: false
 
 permissions:
   contents: write
@@ -88,7 +88,21 @@ jobs:
           files: >
             Manifests:bundle/
 
+  # This new job validates the inputs for the 'create_okd_release_pr' operation.
+  validate_pr_inputs:
+    name: Validate Inputs
+    if: ${{ inputs.operation == 'create_okd_release_pr' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if ocp_version is provided
+        if: ${{ inputs.ocp_version == '' }}
+        run: |
+          echo "Error: The 'ocp_version' input is mandatory when the operation is 'create_okd_release_pr'."
+          exit 1
+
   create_okd_release_pr:
+    # This job now depends on the validation job.
+    needs: validate_pr_inputs
     if: inputs.operation == 'create_okd_release_pr'
     uses: medik8s/.github/.github/workflows/release_community_bundle_parametric.yaml@main
     secrets: inherit


### PR DESCRIPTION
Enhance release workflow by adding input validation for 'create_okd_release_pr' operation and updating 'ocp_version' requirement to optional.

<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->

The inputs bundle-community-okd requiere to set ocp_version. The input build_and_push_images not required ocp_version but they both share the same interface, sine it's mandatory for one of the two, it was set for both.


#### Changes made
<!-- Outline the specific changes made in this merge request. -->

The input for ocp_version in the rest of medik8s operator is not required. To aligned the behavior across all operators, adding input validation task only for release to bundle-community-okd.

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
