### PR TITLE
Fix logging messages when machine has no associated node

### DIFF
--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -60,7 +60,7 @@ const (
 	noMachineAnnotationError           = "failed to find openshift machine annotation on node name: %s"
 	invalidValueMachineAnnotationError = "failed to extract Machine Name and Machine Namespace from machine annotation on the node for node name: %s"
 	failedToDeleteMachineError         = "failed to delete machine of node name: %s"
-	nodeNotFoundErrorMsg               = "could not get the node"
+	nodeNotFoundErrorMsg               = "could not get the node - node not found"
 	machineNotFoundErrorMsg            = "could not get node's machine"
 	noControllerOwnerErrorMsg          = "ignoring remediation of the machine: the machine has no controller owner"
 	// Cluster Provider messages
@@ -200,12 +200,16 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 
 	log.Info("target machine found", "machine", machine.GetName())
 
-	// Verify if the node referenced by the machine can be retrieved
+	// Verify if the node referenced by the machine exists
 	if machine.Status.NodeRef != nil {
 		node := &v1.Node{}
 		nodeKey := client.ObjectKey{Name: machine.Status.NodeRef.Name}
 		if err := r.Get(ctx, nodeKey, node); err != nil {
-			log.Error(err, "failed to get node", "node name", machine.Status.NodeRef.Name)
+			if apiErrors.IsNotFound(err) {
+				log.Error(err, nodeNotFoundErrorMsg, "node name", machine.Status.NodeRef.Name)
+			} else {
+				log.Error(err, "failed to get node", "node name", machine.Status.NodeRef.Name)
+			}
 		}
 	} else {
 		log.Info(machineHasNoNodeRefInfo)

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -63,9 +63,9 @@ const (
 	machineNotFoundErrorMsg            = "could not get node's machine"
 	noControllerOwnerErrorMsg          = "ignoring remediation of the machine: the machine has no controller owner"
 	// Cluster Provider messages
-	machineDeletedOnCloudProviderMessage     = "Machine will be deleted and the unhealthy node replaced. This is a Cloud cluster provider: the new node is expected to have a new name"
-	machineDeletedOnBareMetalProviderMessage = "Machine will be deleted and the unhealthy node replaced. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
-	machineDeletedOnUnknownProviderMessage   = "Machine will be deleted and the unhealthy node replaced. Unknown cluster provider: no information about the new node's name"
+	machineDeletedOnCloudProviderMessage     = "Machine will be deleted for remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
+	machineDeletedOnBareMetalProviderMessage = "Machine will be deleted for remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
+	machineDeletedOnUnknownProviderMessage   = "Machine will be deleted for remediation. Unknown cluster provider: no information about the new node's name"
 )
 
 type conditionChangeReason string
@@ -198,6 +198,17 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 	}
 
 	log.Info("target machine found", "machine", machine.GetName())
+
+	// Check if a node actually exists in the cluster
+	if machine.Status.NodeRef != nil {
+		node := &v1.Node{}
+		nodeKey := client.ObjectKey{Name: machine.Status.NodeRef.Name}
+		if err := r.Get(ctx, nodeKey, node); err != nil {
+			log.Error(err, nodeNotFoundErrorMsg, "node name", machine.Status.NodeRef.Name)
+		}
+	} else {
+		log.Info("machine has no nodeRef")
+	}
 
 	// Detect if Node name is expected to change after Machine deletion given
 	// the Platform type. In case of BareMetal platform, the name is NOT

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -64,9 +64,9 @@ const (
 	machineNotFoundErrorMsg            = "could not get node's machine"
 	noControllerOwnerErrorMsg          = "ignoring remediation of the machine: the machine has no controller owner"
 	// Cluster Provider messages
-	machineDeletedOnCloudProviderMessage     = "Machine will be deleted for remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
-	machineDeletedOnBareMetalProviderMessage = "Machine will be deleted for remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
-	machineDeletedOnUnknownProviderMessage   = "Machine will be deleted for remediation. Unknown cluster provider: no information about the new node's name"
+	machineDeletedOnCloudProviderMessage     = "Machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
+	machineDeletedOnBareMetalProviderMessage = "Machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
+	machineDeletedOnUnknownProviderMessage   = "Machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name"
 )
 
 type conditionChangeReason string
@@ -200,12 +200,12 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 
 	log.Info("target machine found", "machine", machine.GetName())
 
-	// Check if the node actually exists in the cluster
+	// Verify if the node referenced by the machine can be retrieved
 	if machine.Status.NodeRef != nil {
 		node := &v1.Node{}
 		nodeKey := client.ObjectKey{Name: machine.Status.NodeRef.Name}
 		if err := r.Get(ctx, nodeKey, node); err != nil {
-			log.Error(err, nodeNotFoundErrorMsg, "node name", machine.Status.NodeRef.Name)
+			log.Error(err, "failed to get node", "node name", machine.Status.NodeRef.Name)
 		}
 	} else {
 		log.Info(machineHasNoNodeRefInfo)

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -54,6 +54,7 @@ const (
 	// Infos
 	postponedMachineDeletionInfo  = "target machine was not deleted yet"
 	successfulMachineDeletionInfo = "target machine correctly deleted"
+	machineHasNoNodeRefInfo       = "machine has no nodeRef"
 	//Errors
 	noAnnotationsError                 = "failed to find machine annotation on node name: %s"
 	noMachineAnnotationError           = "failed to find openshift machine annotation on node name: %s"
@@ -207,7 +208,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 			log.Error(err, nodeNotFoundErrorMsg, "node name", machine.Status.NodeRef.Name)
 		}
 	} else {
-		log.Info("machine has no nodeRef")
+		log.Info(machineHasNoNodeRefInfo)
 	}
 
 	// Detect if Node name is expected to change after Machine deletion given

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -200,7 +200,7 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 
 	log.Info("target machine found", "machine", machine.GetName())
 
-	// Check if a node actually exists in the cluster
+	// Check if the node actually exists in the cluster
 	if machine.Status.NodeRef != nil {
 		node := &v1.Node{}
 		nodeKey := client.ObjectKey{Name: machine.Status.NodeRef.Name}

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -64,9 +64,9 @@ const (
 	machineNotFoundErrorMsg            = "could not get node's machine"
 	noControllerOwnerErrorMsg          = "ignoring remediation of the machine: the machine has no controller owner"
 	// Cluster Provider messages
-	machineDeletedOnCloudProviderMessage     = "Node's machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
-	machineDeletedOnBareMetalProviderMessage = "Node's machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
-	machineDeletedOnUnknownProviderMessage   = "Node's machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name"
+	machineDeletedOnCloudProviderMessage     = "Machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
+	machineDeletedOnBareMetalProviderMessage = "Machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
+	machineDeletedOnUnknownProviderMessage   = "Machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name"
 )
 
 type conditionChangeReason string
@@ -205,11 +205,13 @@ func (r *MachineDeletionRemediationReconciler) Reconcile(ctx context.Context, re
 		node := &v1.Node{}
 		nodeKey := client.ObjectKey{Name: machine.Status.NodeRef.Name}
 		if err := r.Get(ctx, nodeKey, node); err != nil {
+			var msg string
 			if apiErrors.IsNotFound(err) {
-				log.Error(err, nodeNotFoundErrorMsg, "node name", machine.Status.NodeRef.Name)
+				msg = nodeNotFoundErrorMsg
 			} else {
-				log.Error(err, "failed to get node", "node name", machine.Status.NodeRef.Name)
+				msg = "failed to get node"
 			}
+			log.Error(err, msg+", remediation is safe to continue despite node status", "node name", machine.Status.NodeRef.Name)
 		}
 	} else {
 		log.Info(machineHasNoNodeRefInfo)

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -64,9 +64,9 @@ const (
 	machineNotFoundErrorMsg            = "could not get node's machine"
 	noControllerOwnerErrorMsg          = "ignoring remediation of the machine: the machine has no controller owner"
 	// Cluster Provider messages
-	machineDeletedOnCloudProviderMessage     = "Machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
-	machineDeletedOnBareMetalProviderMessage = "Machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
-	machineDeletedOnUnknownProviderMessage   = "Machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name"
+	machineDeletedOnCloudProviderMessage     = "Node's machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name"
+	machineDeletedOnBareMetalProviderMessage = "Node's machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name"
+	machineDeletedOnUnknownProviderMessage   = "Node's machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name"
 )
 
 type conditionChangeReason string

--- a/controllers/machinedeletionremediation_controller.go
+++ b/controllers/machinedeletionremediation_controller.go
@@ -60,7 +60,7 @@ const (
 	noMachineAnnotationError           = "failed to find openshift machine annotation on node name: %s"
 	invalidValueMachineAnnotationError = "failed to extract Machine Name and Machine Namespace from machine annotation on the node for node name: %s"
 	failedToDeleteMachineError         = "failed to delete machine of node name: %s"
-	nodeNotFoundErrorMsg               = "could not get the node - node not found"
+	nodeNotFoundErrorMsg               = "could not get the node: node not found"
 	machineNotFoundErrorMsg            = "could not get node's machine"
 	noControllerOwnerErrorMsg          = "ignoring remediation of the machine: the machine has no controller owner"
 	// Cluster Provider messages

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name",
+							machineDeletedOnBareMetalProviderMessage,
 							true},
 					})
 				})
@@ -329,7 +329,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name",
+							machineDeletedOnCloudProviderMessage,
 							true},
 					})
 				})
@@ -347,7 +347,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name",
+							machineDeletedOnUnknownProviderMessage,
 							true},
 					})
 				})

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -592,9 +592,9 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					underTest = createRemediationOwnedByMHC("remediation-name", workerNodeMachine)
 				})
 
-				It("MHC worker machine is deleted; logs failed to get node", func() {
+				It("MHC worker machine is deleted; logs node not found error", func() {
 					Eventually(func() bool {
-						return plogs.Contains("failed to get node") && plogs.Contains(workerNodeMachine.Status.NodeRef.Name)
+						return plogs.Contains(nodeNotFoundErrorMsg) && plogs.Contains(workerNodeMachine.Status.NodeRef.Name)
 					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 
 					// Machine should still be deleted despite node not existing

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted for remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name",
+							"Machine will be deleted as part of remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name",
 							true},
 					})
 				})
@@ -329,7 +329,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted for remediation. This is a Cloud cluster provider: the new node is expected to have a new name",
+							"Machine will be deleted as part of remediation. This is a Cloud cluster provider: the new node is expected to have a new name",
 							true},
 					})
 				})
@@ -347,7 +347,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted for remediation. Unknown cluster provider: no information about the new node's name",
+							"Machine will be deleted as part of remediation. Unknown cluster provider: no information about the new node's name",
 							true},
 					})
 				})
@@ -592,9 +592,9 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					underTest = createRemediationOwnedByMHC("remediation-name", workerNodeMachine)
 				})
 
-				It("MHC worker machine is deleted; logs node not found error", func() {
+				It("MHC worker machine is deleted; logs failed to get node", func() {
 					Eventually(func() bool {
-						return plogs.Contains(nodeNotFoundErrorMsg) && plogs.Contains(workerNodeMachine.Status.NodeRef.Name)
+						return plogs.Contains("failed to get node") && plogs.Contains(workerNodeMachine.Status.NodeRef.Name)
 					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 
 					// Machine should still be deleted despite node not existing

--- a/controllers/machinedeletionremediation_controller_test.go
+++ b/controllers/machinedeletionremediation_controller_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted and the unhealthy node replaced. This is a BareMetal cluster provider: the new node is NOT expected to have a new name",
+							"Machine will be deleted for remediation. This is a BareMetal cluster provider: the new node is NOT expected to have a new name",
 							true},
 					})
 				})
@@ -329,7 +329,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted and the unhealthy node replaced. This is a Cloud cluster provider: the new node is expected to have a new name",
+							"Machine will be deleted for remediation. This is a Cloud cluster provider: the new node is expected to have a new name",
 							true},
 					})
 				})
@@ -347,7 +347,7 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					verifyEvents([]expectedEvent{
 						{v1.EventTypeNormal,
 							"PermanentNodeDeletionExpected",
-							"Machine will be deleted and the unhealthy node replaced. Unknown cluster provider: no information about the new node's name",
+							"Machine will be deleted for remediation. Unknown cluster provider: no information about the new node's name",
 							true},
 					})
 				})
@@ -581,7 +581,31 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 				})
 			})
 
-			When("Machine's node does not exist", func() {
+			When("Machine has nodeRef but referenced node does not exist", func() {
+				BeforeEach(func() {
+					// Set nodeRef on the machine pointing to a non-existent node
+					workerNodeMachine.Status.NodeRef = &v1.ObjectReference{
+						Kind: "Node",
+						Name: "missing-test-node",
+					}
+					Expect(k8sClient.Status().Update(context.Background(), workerNodeMachine)).To(Succeed())
+					underTest = createRemediationOwnedByMHC("remediation-name", workerNodeMachine)
+				})
+
+				It("MHC worker machine is deleted; logs node not found error", func() {
+					Eventually(func() bool {
+						return plogs.Contains(nodeNotFoundErrorMsg) && plogs.Contains(workerNodeMachine.Status.NodeRef.Name)
+					}, 30*time.Second, 1*time.Second).Should(BeTrue())
+
+					// Machine should still be deleted despite node not existing
+					verifyMachineIsDeleted(workerNodeMachineName)
+					verifyEvents([]expectedEvent{
+						{v1.EventTypeNormal, "RemediationStarted", "Remediation started", true},
+					})
+				})
+			})
+
+			When("Machine has no nodeRef", func() {
 				BeforeEach(func() {
 					// The actual remediation name should be the same as the Machine's name, however
 					// the test use a different name to make sure the target Machine is not found looking at the
@@ -589,7 +613,10 @@ var _ = Describe("Machine Deletion Remediation CR", func() {
 					underTest = createRemediationOwnedByMHC("remediation-name", phantomNodeMachine)
 				})
 
-				It("MHC worker machine is deleted", func() {
+				It("MHC worker machine is deleted; logs machine has no nodeRef", func() {
+					Eventually(func() bool {
+						return plogs.Contains(machineHasNoNodeRefInfo)
+					}, 30*time.Second, 1*time.Second).Should(BeTrue())
 					verifyMachineIsDeleted(phantomNodeMachineName)
 					verifyMachineNotDeleted(workerNodeMachineName)
 					verifyMachineNotDeleted(masterNodeMachineName)


### PR DESCRIPTION
#### Why we need this PR
Fixes inaccurate logging when remediating machines without associated nodes.

#### Changes made
  - Add node existence check when machine has nodeRef
  - Update provider messages from "unhealthy node replaced" to "for remediation"
  - Add test coverage for both scenarios:
    - Machine with nodeRef pointing to missing node (logs ERROR)
    - Machine with no nodeRef (logs INFO)


#### Which issue(s) this PR fixes

Fixes [ECOPROJECT-1840](https://redhat.atlassian.net/browse/ECOPROJECT-1840)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a machine references a missing node: clearer node-not-found logs and distinct log when a machine has no nodeRef.
  * Standardized remediation event wording across providers to state machines are “deleted as part of remediation”.

* **Tests**
  * Updated tests to cover nodeRef vs non-existent referenced node, asserting new log messages and the revised event wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->