### PR TITLE
Detect host architecture for GOARCH in build script

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -29,4 +29,14 @@ echo "cgo: ${CGO_ENABLED}"
 # export in case it was set
 export GOEXPERIMENT="${GOEXPERIMENT}"
 
-GOOS=linux GOARCH=amd64 go build -o "${DEST_DIR}"/manager main.go
+# Detect target architecture
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64)   GOARCH="amd64"   ;;
+  aarch64|arm64) GOARCH="arm64" ;;
+  s390x)    GOARCH="s390x"   ;;
+  ppc64le)  GOARCH="ppc64le" ;;
+  *)        echo "Unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+
+GOOS=linux GOARCH=${GOARCH} go build -o "${DEST_DIR}"/manager main.go

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -29,4 +29,6 @@ echo "cgo: ${CGO_ENABLED}"
 # export in case it was set
 export GOEXPERIMENT="${GOEXPERIMENT}"
 
-GOOS=linux GOARCH=amd64 go build -o "${DEST_DIR}"/manager cmd/main.go
+# detect target arch from Go toolchain, default to amd64
+GOARCH=$(go env GOARCH)
+GOOS=linux GOARCH=${GOARCH:-amd64} go build -o "${DEST_DIR}"/manager cmd/main.go


### PR DESCRIPTION
#### Why we need this PR

`hack/build.sh` hardcodes `GOARCH=amd64`, which prevents building the operator binary on non-x86_64 hosts (e.g. arm64, s390x, ppc64le). Anyone building on those platforms must manually override GOARCH.

#### Changes made

- Detect host architecture at build time using `go env GOARCH`
- Fall back to `amd64` if the value is empty (safeguard)
- No behavior change on x86_64 hosts (`go env GOARCH` returns `amd64`, same as before)

#### Which issue(s) this PR fixes

Related to [RHWA-514](https://redhat.atlassian.net/browse/RHWA-514). Enables the Go binary build to work on non-amd64 hosts.

#### Test plan

- Existing CI runs on amd64 and produces identical behavior (no regression)
- `go env GOARCH` returns the correct architecture on all supported platforms