### PR TITLE
Bump Go toolchain to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/medik8s/machine-deletion-remediation
 go 1.24.11
 
 // latest downstream version for security patches
-toolchain go1.25.3
+toolchain go1.25.10
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION

#### Why we need this PR
A number of security patches are included in go>=1.25.9

#### Changes made
Update the toolchain directive in go.mod from go1.25.3 to go1.25.10

Addressing the CVEs requires Go >= 1.25.9, while the `sigs.k8s.io/controller-tools` v0.20.0 dependency requires Go >=1.25.0 and automatically downloads the latest patch patch release in 1.25 series.

#### Which issue(s) this PR fixes

Fixes: [RHWA-730](https://redhat.atlassian.net/browse/RHWA-730) [RHWA-686](https://redhat.atlassian.net/browse/RHWA-686) [RHWA-681](https://redhat.atlassian.net/browse/RHWA-681) [RHWA-796](https://redhat.atlassian.net/browse/RHWA-796) [RHWA-807](https://redhat.atlassian.net/browse/RHWA-807) [RHWA-867](https://redhat.atlassian.net/browse/RHWA-867) [RHWA-883](https://redhat.atlassian.net/browse/RHWA-883) [RHWA-878](https://redhat.atlassian.net/browse/RHWA-878)

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to improve build stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->