### PR TITLE
Add bundle-run-update Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,17 +366,17 @@ bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
 .PHONY: bundle-run
-export BUNDLE_RUN_NAMESPACE ?= openshift-workload-availability
+OPERATOR_NAMESPACE ?= openshift-workload-availability
 bundle-run: operator-sdk ## Run bundle image
-	$(OPERATOR_SDK) -n $(BUNDLE_RUN_NAMESPACE) run bundle $(BUNDLE_IMG)
+	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) run bundle $(BUNDLE_IMG)
 
 .PHONY: bundle-run-update
 bundle-run-update: operator-sdk ## Upgrade bundle image
-	$(OPERATOR_SDK) -n $(BUNDLE_RUN_NAMESPACE) run bundle-upgrade $(BUNDLE_IMG)
+	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) run bundle-upgrade $(BUNDLE_IMG)
 
 .PHONY: bundle-cleanup
 bundle-cleanup: operator-sdk ## Remove bundle installed via bundle-run
-	$(OPERATOR_SDK) -n $(BUNDLE_RUN_NAMESPACE) cleanup $(OPERATOR_NAME)
+	$(OPERATOR_SDK) -n $(OPERATOR_NAMESPACE) cleanup $(OPERATOR_NAME)
 
 # Build a file-based catalog image
 # https://docs.openshift.com/container-platform/4.14/operators/admin/olm-managing-custom-catalogs.html#olm-managing-custom-catalogs-fb

--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,10 @@ export BUNDLE_RUN_NAMESPACE ?= openshift-workload-availability
 bundle-run: operator-sdk ## Run bundle image
 	$(OPERATOR_SDK) -n $(BUNDLE_RUN_NAMESPACE) run bundle $(BUNDLE_IMG)
 
+.PHONY: bundle-run-update
+bundle-run-update: operator-sdk ## Upgrade bundle image
+	$(OPERATOR_SDK) -n $(BUNDLE_RUN_NAMESPACE) run bundle-upgrade $(BUNDLE_IMG)
+
 .PHONY: bundle-cleanup
 bundle-cleanup: operator-sdk ## Remove bundle installed via bundle-run
 	$(OPERATOR_SDK) -n $(BUNDLE_RUN_NAMESPACE) cleanup $(OPERATOR_NAME)


### PR DESCRIPTION
## Why we need this PR

Other medik8s operators (FAR, NMO, SNR, SBR) already have a `bundle-run-update`
Makefile target for OLM-based upgrade testing. MDR is missing this target, which
prevents adding CI upgrade testing (install released version → upgrade → test).

Additionally, MDR was the only operator using `BUNDLE_RUN_NAMESPACE` instead of
`OPERATOR_NAMESPACE` for the bundle namespace variable.

## Changes made

- Add `bundle-run-update` Makefile target wrapping `operator-sdk run bundle-upgrade`
- Rename `BUNDLE_RUN_NAMESPACE` to `OPERATOR_NAMESPACE` across `bundle-run`,
  `bundle-run-update`, and `bundle-cleanup` targets — aligns with all other
  medik8s repos (FAR, NMO, SNR, NHC, SBR)

No CI impact — the openshift/release CI configs use `INSTALL_NAMESPACE` and
call `operator-sdk` directly, not `make bundle-run`.

## Which issue(s) this PR fixes

https://redhat.atlassian.net/browse/RHWA-1201

See also https://github.com/openshift/release/pull/81183 for CI changes to MDR.

## Test plan

- [ ] `make bundle-run-update` target is recognized by make
- [ ] Target correctly calls `operator-sdk run bundle-upgrade` with `OPERATOR_NAMESPACE`
- [ ] `make bundle-run` and `make bundle-cleanup` still work with renamed variable
- [ ] `OPERATOR_NAMESPACE=custom-ns make bundle-run` overrides correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bundle update option to upgrade the bundle image using the configured namespace and image settings.
* **Chores / Maintenance**
  * Updated bundle run and cleanup commands to use the same configured namespace consistently for bundle image operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->