### PR TITLE
Add NetworkPolicy RBAC permission

### DIFF
--- a/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
+++ b/bundle/manifests/machine-deletion-remediation.clusterserviceversion.yaml
@@ -176,6 +176,14 @@ spec:
           - update
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,3 +59,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - update

--- a/internal/controller/machinedeletionremediation_controller.go
+++ b/internal/controller/machinedeletionremediation_controller.go
@@ -102,6 +102,7 @@ type MachineDeletionRemediationReconciler struct {
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=machinesets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=machine.openshift.io,resources=controlplanemachinesets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## Summary

Add `networking.k8s.io/networkpolicies` RBAC (create, delete, update) to allow managing NetworkPolicies for operand workloads.

## Changes

- Add kubebuilder RBAC marker to controller
- Regenerate `config/rbac/role.yaml`
- Regenerate bundle CSV

## Test plan

- [x] `make manifests` — RBAC generated correctly
- [x] `make bundle-reset` — bundle validates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)